### PR TITLE
Add helper methods to insert insn list at a specified method calls

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -5,6 +5,8 @@ import cpw.mods.modlauncher.api.INameMappingService;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
 
+import java.util.Iterator;
+
 public class ASMAPI {
     public static MethodNode getMethodNode() {
         return new MethodNode(Opcodes.ASM6);
@@ -15,11 +17,15 @@ public class ASMAPI {
     }
 
     public enum MethodType {
-        VIRTUAL, SPECIAL, STATIC, INTERFACE
+        VIRTUAL, SPECIAL, STATIC, INTERFACE;
+
+        public int toOpcode() {
+            return Opcodes.INVOKEVIRTUAL + this.ordinal();
+        }
     }
 
     public static MethodInsnNode buildMethodCall(final String ownerName, final String methodName, final String methodDescriptor, final MethodType type) {
-        return new MethodInsnNode(type.ordinal()+Opcodes.INVOKEVIRTUAL, ownerName, methodName, methodDescriptor, type==MethodType.INTERFACE);
+        return new MethodInsnNode(type.toOpcode(), ownerName, methodName, methodDescriptor, type==MethodType.INTERFACE);
     }
 
     public static String mapMethod(String name) {
@@ -36,5 +42,57 @@ public class ASMAPI {
 
     public static boolean getSystemPropertyFlag(final String propertyName) {
         return Boolean.getBoolean(System.getProperty("coremod."+propertyName, "TRUE"));
+    }
+
+    public enum InsertMode {
+        REMOVE_ORIGINAL, INSERT_BEFORE, INSERT_AFTER
+    }
+
+    /**
+     * Inserts/replaces a list after/before first {@link MethodInsnNode} that matches the parameters of these functions in the method provided.
+     * @param method The method where you want to find the node
+     * @param type The type of the old method node.
+     * @param owner The owner of the old method node.
+     * @param name The name of the old method node. You may want to use {@link #mapMethod(String)} if this is a srg name
+     * @param desc The desc of the old method node.
+     * @param list The list that should be inserted
+     * @param targetAll If true, all node that match the 3 params are targeted. Otherwise, only the first one is chosen.
+     * @param mode How the given code should be inserted
+     * @return The count of the replacements made
+     */
+    public static int insertInsnList(MethodNode method, MethodType type, String owner, String name, String desc, InsnList list, boolean targetAll, InsertMode mode) {
+        Iterator<AbstractInsnNode> nodeIterator = method.instructions.iterator();
+        int opcode = type.toOpcode();
+        int counter = 0;
+        while (nodeIterator.hasNext()) {
+            AbstractInsnNode next = nodeIterator.next();
+            if (next.getOpcode() == opcode) {
+                MethodInsnNode castedNode = (MethodInsnNode) next;
+                if (castedNode.owner.equals(owner) && castedNode.name.equals(name) && castedNode.desc.equals(desc)) {
+                    if (mode == InsertMode.INSERT_BEFORE)
+                        method.instructions.insertBefore(next, list);
+                    else
+                        method.instructions.insert(next, list);
+
+                    if (mode == InsertMode.REMOVE_ORIGINAL)
+                        nodeIterator.remove();
+                    counter++;
+                    if (!targetAll) break;
+                }
+            }
+        }
+        return counter;
+    }
+
+    /**
+     * Builds a new {@link InsnList} out of the specified AbstractInsnNodes
+     * @param nodes The nodes you want to add
+     * @return A new list with the nodes
+     */
+    public static InsnList listOf(AbstractInsnNode... nodes) {
+        InsnList list = new InsnList();
+        for (AbstractInsnNode node : nodes)
+            list.add(node);
+        return list;
     }
 }


### PR DESCRIPTION
This allows code that replaces or adds calls before method calls to be much smaller and easier.
This is a very common usecase, mostly for replacing method calls or calling something before/after a method call.
Example JS code before this change:
```javascript
var Opcodes = Java.type('org.objectweb.asm.Opcodes');
var ASMAPI = Java.type('net.minecraftforge.coremod.api.ASMAPI');
var found = false;
for (var i = 0; i < arrayLength; ++i) {
    var instruction = method.instructions.get(i);
    if (instruction.getOpcode() === Opcodes.INVOKESTATIC && instruction.owner === "org/lwjgl/openal/ALC10" && instruction.name === "alcOpenDevice" && instruction.desc === "(Ljava/nio/ByteBuffer;)J") {
        method.instructions.insertBefore(instruction, ASMAPI.buildMethodCall("ichttt/mods/sounddeviceoptions/client/ASMHooks", "setupSound", "(Ljava/nio/ByteBuffer;)J", ASMAPI.MethodType.STATIC))
        method.instructions.remove(instruction);
        found = true;
        break;
    }
}
if (found === false) {
    throw "MethodInsnNode not found!";
}
```
This could be trimmed to this with these changes:
```javascript
var ASMAPI = Java.type('net.minecraftforge.coremod.api.ASMAPI');
var newList = ASMAPI.listOf(ASMAPI.buildMethodCall("ichttt/mods/sounddeviceoptions/client/ASMHooks", "setupSound", "(Ljava/nio/ByteBuffer;)J", ASMAPI.MethodType.STATIC));
if (ASMAPI.insertInsnList(method, ASMAPI.MethodType.STATIC, "org/lwjgl/openal/ALC10", "alcOpenDevice", "(Ljava/nio/ByteBuffer;)J", newList, false, ASMAPI.InsertMode.REMOVE_ORIGINAL) !== 1) {
    throw "MethodInsnNode not found!";
}
```