### PR TITLE
Add tests and fix new insertInsnList method

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -54,20 +54,19 @@ public class ASMAPI {
 
     /**
      * Inserts/replaces a list after/before first {@link MethodInsnNode} that matches the parameters of these functions in the method provided.
+     * Only the first node matching is targeted, all other matches are ignored.
      * @param method The method where you want to find the node
      * @param type The type of the old method node.
      * @param owner The owner of the old method node.
      * @param name The name of the old method node. You may want to use {@link #mapMethod(String)} if this is a srg name
      * @param desc The desc of the old method node.
      * @param list The list that should be inserted
-     * @param targetAll If true, all node that match the 3 params are targeted. Otherwise, only the first one is chosen.
      * @param mode How the given code should be inserted
-     * @return The count of the replacements made
+     * @return True if the node was found, false otherwise
      */
-    public static int insertInsnList(MethodNode method, MethodType type, String owner, String name, String desc, InsnList list, boolean targetAll, InsertMode mode) {
+    public static boolean insertInsnList(MethodNode method, MethodType type, String owner, String name, String desc, InsnList list, InsertMode mode) {
         Iterator<AbstractInsnNode> nodeIterator = method.instructions.iterator();
         int opcode = type.toOpcode();
-        int counter = 0;
         while (nodeIterator.hasNext()) {
             AbstractInsnNode next = nodeIterator.next();
             if (next.getOpcode() == opcode) {
@@ -80,12 +79,11 @@ public class ASMAPI {
 
                     if (mode == InsertMode.REMOVE_ORIGINAL)
                         nodeIterator.remove();
-                    counter++;
-                    if (!targetAll) break;
+                    return true;
                 }
             }
         }
-        return counter;
+        return false;
     }
 
     /**

--- a/src/test/java/net/minecraftforge/coremod/ArmsLengthHandler.java
+++ b/src/test/java/net/minecraftforge/coremod/ArmsLengthHandler.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 
 import java.util.concurrent.Callable;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class ArmsLengthHandler implements Callable<Void> {
@@ -11,8 +12,14 @@ public class ArmsLengthHandler implements Callable<Void> {
     public Void call() throws Exception {
         final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         LogManager.getLogger().info("CCL is {}", contextClassLoader);
-        final Class<?> aClass = Class.forName("cpw.mods.TestClass", true, contextClassLoader);
-        assertFalse((Boolean)aClass.getMethod("testMethod").invoke(null));
+        final Class<?> testClass = Class.forName("cpw.mods.TestClass", true, contextClassLoader);
+        assertFalse((boolean)testClass.getMethod("testMethod").invoke(null));
+
+        boolean result = (boolean)testClass.getMethod("testInsert").invoke(null);
+        assertFalse(result);
+        final Class<?> redirectClass = Class.forName("cpw.mods.RedirectClass", true, contextClassLoader);
+        assertEquals(1, (int) redirectClass.getMethod("getAfterCallCount").invoke(null));
+        assertEquals(1, (int) redirectClass.getMethod("getBeforeCallCount").invoke(null));
         return null;
     }
 }

--- a/src/test/java/net/minecraftforge/coremod/TestLaunchTransformer.java
+++ b/src/test/java/net/minecraftforge/coremod/TestLaunchTransformer.java
@@ -22,6 +22,7 @@ public class TestLaunchTransformer {
         cme.loadCoreMod(new JSFileLoader("src/test/javascript/testcoremod.js"));
         cme.loadCoreMod(new JSFileLoader("src/test/javascript/testcore2mod.js"));
         cme.loadCoreMod(new JSFileLoader("src/test/javascript/testmethodcoremod.js"));
+        cme.loadCoreMod(new JSFileLoader("src/test/javascript/testmethodcoreinsert.js"));
 
         Launcher.main("--version", "1.0", "--launchTarget", "testharness");
     }

--- a/src/test/javascript/testmethodcoreinsert.js
+++ b/src/test/javascript/testmethodcoreinsert.js
@@ -1,0 +1,32 @@
+function initializeCoreMod() {
+    return {
+        'coremodmethod': {
+            'target': {
+                'type': 'METHOD',
+                'class': 'cpw.mods.TestClass',
+                'methodName': 'testInsert',
+                'methodDesc': '()Z'
+            },
+            'transformer': function(method) {
+                var ASMAPI = Java.type('net.minecraftforge.coremod.api.ASMAPI');
+                var newList1 = ASMAPI.listOf(ASMAPI.buildMethodCall("cpw/mods/RedirectClass", "newMethod", "()Z", ASMAPI.MethodType.STATIC));
+                if (ASMAPI.insertInsnList(method, ASMAPI.MethodType.STATIC, "cpw/mods/TestClass", "testMethod2", "()Z", newList1, ASMAPI.InsertMode.REMOVE_ORIGINAL) === false) {
+                    throw "MethodInsnNode for testMethod2 not found!";
+                }
+
+                var newList2 = ASMAPI.listOf(ASMAPI.buildMethodCall("cpw/mods/RedirectClass", "afterMethod", "()V", ASMAPI.MethodType.STATIC));
+                if (ASMAPI.insertInsnList(method, ASMAPI.MethodType.STATIC, "cpw/mods/TestClass", "testMethod1", "()J", newList2, ASMAPI.InsertMode.INSERT_AFTER) === false) {
+                    throw "MethodInsnNode for insert after on testMethod1 not found!";
+                }
+
+                var newList3 = ASMAPI.listOf(ASMAPI.buildMethodCall("cpw/mods/RedirectClass", "beforeMethod", "()V", ASMAPI.MethodType.STATIC));
+                if (ASMAPI.insertInsnList(method, ASMAPI.MethodType.STATIC, "cpw/mods/TestClass", "testMethod1", "()J", newList3, ASMAPI.InsertMode.INSERT_BEFORE) === false) {
+                    throw "MethodInsnNode for insert before on testMethod1 not found!";
+                }
+
+                print("Redirects added!")
+                return method;
+            }
+        }
+    }
+}

--- a/src/testJars/java/cpw/mods/RedirectClass.java
+++ b/src/testJars/java/cpw/mods/RedirectClass.java
@@ -1,0 +1,26 @@
+package cpw.mods;
+
+public class RedirectClass {
+    private static int beforeCallCount = 0;
+    private static int afterCallCount = 0;
+
+    public static boolean newMethod() {
+        return false;
+    }
+
+    public static void afterMethod() {
+        afterCallCount++;
+    }
+
+    public static void beforeMethod() {
+        beforeCallCount++;
+    }
+
+    public static int getBeforeCallCount() {
+        return beforeCallCount;
+    }
+
+    public static int getAfterCallCount() {
+        return afterCallCount;
+    }
+}

--- a/src/testJars/java/cpw/mods/TestClass.java
+++ b/src/testJars/java/cpw/mods/TestClass.java
@@ -12,4 +12,19 @@ public class TestClass {
     public static void main(String... args) {
         cheese();
     }
+
+    public static boolean testInsert() {
+        testMethod1();
+        boolean result = testMethod2();
+        testMethod1();
+        return result;
+    }
+
+    public static long testMethod1() {
+        return (long) (Math.random() * 3290L);
+    }
+
+    public static boolean testMethod2() {
+        return true;
+    }
 }


### PR DESCRIPTION
The targetAll parameter was only useful in very few cases to begin with, but unfortunally, I needed to remove the targetAll parameter, because the ASM lib stores the previous and next node in the node itself, without giving us a possiblitiy to clone the list in before, so I just removed it.