### PR TITLE
Additional utility methods for finding methods and generic instructions

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -53,6 +53,123 @@ public class ASMAPI {
     }
 
     /**
+     * Finds the first instruction with matching opcode
+     *
+     * @param method the method to search in
+     * @param opCode the opcode to search for
+     * @return the found instruction node or null if none matched
+     */
+    public static AbstractInsnNode findFirstInstruction(MethodNode method, int opCode) {
+        return findFirstInstructionAfter(method, opCode, 0);
+    }
+
+    /**
+     * Finds the first instruction with matching opcode after the given start index
+     *
+     * @param method the method to search in
+     * @param opCode the opcode to search for
+     * @param startIndex the index to start search after (inclusive)
+     * @return the found instruction node or null if none matched after the given index
+     */
+    public static AbstractInsnNode findFirstInstructionAfter(MethodNode method, int opCode, int startIndex) {
+        for (int i = Math.max(0, startIndex); i < method.instructions.size(); i++) {
+            AbstractInsnNode ain = method.instructions.get(i);
+            if (ain.getOpcode() == opCode) {
+                return ain;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the first instruction with matching opcode before the given index in reverse search
+     *
+     * @param method the method to search in
+     * @param opCode the opcode to search for
+     * @param startIndex the index at which to start searching (inclusive)
+     * @return the found instruction node or null if none matched before the given startIndex
+     */
+    public static AbstractInsnNode findFirstInstructionBefore(MethodNode method, int opCode, int startIndex) {
+        for (int i = Math.max(method.instructions.size() - 1, startIndex); i >= 0; i--) {
+            AbstractInsnNode ain = method.instructions.get(i);
+            if (ain.getOpcode() == opCode) {
+                return ain;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the first method call in the given method matching the given type, owner, name and descriptor
+     *
+     * @param method the method to search in
+     * @param type the type of method call to search for
+     * @param owner the method call's owner to search for
+     * @param name the method call's name
+     * @param descriptor the method call's descriptor
+     * @return the found method call node or null if none matched
+     */
+    public static MethodInsnNode findFirstMethodCall(MethodNode method, MethodType type, String owner, String name, String descriptor) {
+        return findFirstMethodCallAfter(method, type, owner, name, descriptor, 0);
+    }
+
+    /**
+     * Finds the first method call in the given method matching the given type, owner, name and descriptor
+     * after the instruction given index
+     *
+     * @param method the method to search in
+     * @param type the type of method call to search for
+     * @param owner the method call's owner to search for
+     * @param name the method call's name
+     * @param descriptor the method call's descriptor
+     * @param startIndex the index after which to start searching (inclusive)
+     * @return the found method call node, null if none matched after the given index
+     */
+    public static MethodInsnNode findFirstMethodCallAfter(MethodNode method, MethodType type, String owner, String name, String descriptor, int startIndex) {
+        for (int i = Math.max(0, startIndex); i < method.instructions.size(); i++) {
+            AbstractInsnNode node = method.instructions.get(i);
+            if (node instanceof MethodInsnNode &&
+                    node.getOpcode() == type.toOpcode()) {
+                MethodInsnNode methodInsnNode = (MethodInsnNode) node;
+                if (methodInsnNode.owner.equals(owner) &&
+                        methodInsnNode.name.equals(name) &&
+                        methodInsnNode.desc.equals(descriptor)) {
+                    return methodInsnNode;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the first method call in the given method matching the given type, owner, name and descriptor
+     * before the given index in reverse search
+     *
+     * @param method the method to search in
+     * @param type the type of method call to search for
+     * @param owner the method call's owner to search for
+     * @param name the method call's name
+     * @param descriptor the method call's descriptor
+     * @param startIndex the index at which to start searching (inclusive)
+     * @return the found method call node or null if none matched before the given startIndex
+     */
+    public static MethodInsnNode findFirstMethodCallBefore(MethodNode method, MethodType type, String owner, String name, String descriptor, int startIndex) {
+        for (int i = Math.max(method.instructions.size() - 1, startIndex); i >= 0; i--) {
+            AbstractInsnNode node = method.instructions.get(i);
+            if (node instanceof MethodInsnNode &&
+                    node.getOpcode() == type.toOpcode()) {
+                MethodInsnNode methodInsnNode = (MethodInsnNode) node;
+                if (methodInsnNode.owner.equals(owner) &&
+                        methodInsnNode.name.equals(name) &&
+                        methodInsnNode.desc.equals(descriptor)) {
+                    return methodInsnNode;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Inserts/replaces a list after/before first {@link MethodInsnNode} that matches the parameters of these functions in the method provided.
      * Only the first node matching is targeted, all other matches are ignored.
      * @param method The method where you want to find the node


### PR DESCRIPTION
This PR adds utility functions for searching instructions in MethodNodes.

Specifically this allows for easier search of:

- First instruction with matching opCode
- First method call with matching type, owner, name, description
- First instruction with matching opCode _after_ a specific instruction index
- First method call with matching type, owner, name, description _after_ a specific instruction index
- First instruction with matching opCode _before_ a specific instruction index in reverse search from that index backwards
- First method call with matching type, owner, name, description _before_ a specific instruction index in reverse search from that index backwards

All the search methods return null if no matching result is found.