### PR TITLE
Allow access to load and loadWithNewGlobal

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/CoreMod.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreMod.java
@@ -35,7 +35,7 @@ public class CoreMod {
             ScriptObjectMirror som = (ScriptObjectMirror) scriptEngine.eval(file.readCoreMod());
             this.javaScript = (Map<String, ScriptObjectMirror>) ((Invocable) scriptEngine).invokeFunction("initializeCoreMod");
             this.loaded = true;
-        } catch (IOException | ScriptException | NoSuchMethodException e) {
+        } catch (IOException | ScriptException | NoSuchMethodException | SecurityException e) {
             this.loaded = false;
             this.error = e;
         }

--- a/src/main/java/net/minecraftforge/coremod/CoreModEngine.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreModEngine.java
@@ -51,12 +51,10 @@ public class CoreModEngine {
         );
 
         final ScriptContext jsContext = scriptEngine.getContext();
-        // remove the load, loadWithNewGlobal, exit and quit methods from javascript.
+        // remove the exit and quit methods from javascript.
         // They don't serve a useful purpose and can cause annoying holes in what is
         // meant to be a sandboxed environment.
-        jsContext.removeAttribute("load", jsContext.getAttributesScope("load"));
         jsContext.removeAttribute("quit", jsContext.getAttributesScope("quit"));
-        jsContext.removeAttribute("loadWithNewGlobal", jsContext.getAttributesScope("loadWithNewGlobal"));
         jsContext.removeAttribute("exit", jsContext.getAttributesScope("exit"));
         coreMods.add(new CoreMod(coremod, scriptEngine));
     }

--- a/src/main/java/net/minecraftforge/coremod/CoreModEngine.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreModEngine.java
@@ -60,7 +60,13 @@ public class CoreModEngine {
     }
 
     public List<ITransformer<?>> initializeCoreMods() {
+		SecurityManager oldSecurityManager = System.getSecurityManager();
+        SecurityManager coreModSecurityManager = new CoreModSecurityManager(oldSecurityManager);
+        // Set the security manager to our security manager without network access 
+        System.setSecurityManager(coreModSecurityManager);
         coreMods.forEach(this::initialize);
+        // Set the security manager back to what it originally was
+		System.setSecurityManager(oldSecurityManager);
         return coreMods.stream().map(CoreMod::buildTransformers).flatMap(List::stream).collect(Collectors.toList());
     }
 

--- a/src/main/java/net/minecraftforge/coremod/CoreModEngine.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreModEngine.java
@@ -60,13 +60,13 @@ public class CoreModEngine {
     }
 
     public List<ITransformer<?>> initializeCoreMods() {
-		SecurityManager oldSecurityManager = System.getSecurityManager();
+        SecurityManager oldSecurityManager = System.getSecurityManager();
         SecurityManager coreModSecurityManager = new CoreModSecurityManager(oldSecurityManager);
         // Set the security manager to our security manager without network access 
         System.setSecurityManager(coreModSecurityManager);
         coreMods.forEach(this::initialize);
         // Set the security manager back to what it originally was
-		System.setSecurityManager(oldSecurityManager);
+        System.setSecurityManager(oldSecurityManager);
         return coreMods.stream().map(CoreMod::buildTransformers).flatMap(List::stream).collect(Collectors.toList());
     }
 

--- a/src/main/java/net/minecraftforge/coremod/CoreModSecurityManager.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreModSecurityManager.java
@@ -3,36 +3,36 @@ package net.minecraftforge.coremod;
 import java.security.Permission;
 
 public class CoreModSecurityManager extends SecurityManager {
-		private final SecurityManager oldSecurityManager;
+    private final SecurityManager oldSecurityManager;
 
-		public CoreModSecurityManager(SecurityManager oldSecurityManager) {
-			this.oldSecurityManager = oldSecurityManager;
-		}
+    public CoreModSecurityManager(SecurityManager oldSecurityManager) {
+        this.oldSecurityManager = oldSecurityManager;
+    }
 
-		@Override
-		public void checkConnect(String host, int port) {
-			throw constructException(host, port);
-		}
+    @Override
+    public void checkConnect(String host, int port) {
+        throw constructException(host, port);
+    }
 
-		@Override
-		public void checkConnect(String host, int port, Object context) {
-			throw constructException(host, port);
-		}
-		
-		private SecurityException constructException(String host, int port) {
-			String url = host + (port > -1 ? ":" + port" : "");
-			return new SecurityException("Connection to " + url + " was blocked; loading remote scripts is not allowed.");
-		}
+    @Override
+    public void checkConnect(String host, int port, Object context) {
+        throw constructException(host, port);
+    }
+        
+    private SecurityException constructException(String host, int port) {
+        String url = host + (port > -1 ? ":" + port" : "");
+        return new SecurityException("Connection to " + url + " was blocked; loading remote scripts is not allowed.");
+    }
 
-		@Override
-		public void checkPermission(Permission perm) {
-			if (oldSecurityManager != null)
-				oldSecurityManager.checkPermission(perm);
-		}
+    @Override
+    public void checkPermission(Permission perm) {
+        if (oldSecurityManager != null)
+            oldSecurityManager.checkPermission(perm);
+    }
 
-		@Override
-		public void checkPermission(Permission perm, Object context) {
-			if (oldSecurityManager != null)
-				oldSecurityManager.checkPermission(perm, context);
-		}
-	}
+    @Override
+    public void checkPermission(Permission perm, Object context) {
+        if (oldSecurityManager != null)
+            oldSecurityManager.checkPermission(perm, context);
+    }
+}

--- a/src/main/java/net/minecraftforge/coremod/CoreModSecurityManager.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreModSecurityManager.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.coremod;
+
+import java.security.Permission;
+
+public class CoreModSecurityManager extends SecurityManager {
+		private final SecurityManager oldSecurityManager;
+
+		public CoreModSecurityManager(SecurityManager oldSecurityManager) {
+			this.oldSecurityManager = oldSecurityManager;
+		}
+
+		@Override
+		public void checkConnect(String host, int port) {
+			throw constructException(host, port);
+		}
+
+		@Override
+		public void checkConnect(String host, int port, Object context) {
+			throw constructException(host, port);
+		}
+		
+		private SecurityException constructException(String host, int port) {
+			String url = host + (port > -1 ? ":" + port" : "");
+			return new SecurityException("Connection to " + url + " was blocked; loading remote scripts is not allowed.");
+		}
+
+		@Override
+		public void checkPermission(Permission perm) {
+			if (oldSecurityManager != null)
+				oldSecurityManager.checkPermission(perm);
+		}
+
+		@Override
+		public void checkPermission(Permission perm, Object context) {
+			if (oldSecurityManager != null)
+				oldSecurityManager.checkPermission(perm, context);
+		}
+	}


### PR DESCRIPTION
Allow CoreMods to load other javascript files and reference them. This way, developers could have a file for commonly used methods. This is a problem I encountered when writing my CoreMods, requiring me to have about forty lines of duplicated code in every file, which is often longer than the actual CoreMod itself.