### PR TITLE
Fix findFirstMethodCallBefore

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -158,7 +158,7 @@ public class ASMAPI {
      * @return the found method call node or null if none matched before the given startIndex
      */
     public static MethodInsnNode findFirstMethodCallBefore(MethodNode method, MethodType type, String owner, String name, String descriptor, int startIndex) {
-        for (int i = Math.max(method.instructions.size() - 1, startIndex); i >= 0; i--) {
+        for (int i = Math.min(method.instructions.size() - 1, startIndex); i >= 0; i--) {
             AbstractInsnNode node = method.instructions.get(i);
             if (node instanceof MethodInsnNode &&
                     node.getOpcode() == type.toOpcode()) {


### PR DESCRIPTION
Fix searching backwards always starting at last instruction rather than the passed, ideally lower, start index.

Example:
Through other search methods i found myself at instruction index 200 of a 3000 instruction-long method.
I know the point i want to inject into is prior to this point, let's say "probably" at around 150.
I'd search backwards from 200 down until i hit that instruction.
However, this method, instead of starting at 200, starts at "max(3000, 200)" which is obviously incorrect.