### PR TITLE
Fix bugged logic in ASMAPI.getSystemPropertyFlag()

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -57,17 +57,13 @@ public class ASMAPI {
     }
 
     public static boolean getSystemPropertyFlag(final String propertyName) {
-        // this has the property that CoreMods is looking for
-        String property = System.getProperty("coremod."+propertyName, "TRUE");
+        return Boolean.getBoolean("coremod."+propertyName) || getSystemPropertyFlagOld(propertyName);
+    }
 
-        // oldLogic = bugged logic that remains included for logical compatibility
-        // newLogic = fixed logic that actually checks if the system property is set to true
-        boolean oldLogic = Boolean.getBoolean(property);
-        boolean newLogic = Boolean.parseBoolean(property);
-
-        // while the two variables can be simplified into a single || statement, this improves readability
-        // and explains the bugged code that caused it in the first place
-        return newLogic || oldLogic;
+    /** @deprecated Contains the old, bugged logic that {@link #getSystemPropertyFlag(String)} used to have. */
+    @Deprecated(forRemoval = true, since = "5.0")
+    private static boolean getSystemPropertyFlagOld(final String propertyName) {
+        return Boolean.getBoolean(System.getProperty("coremod."+propertyName, "TRUE"));
     }
 
     public enum InsertMode {

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -57,7 +57,17 @@ public class ASMAPI {
     }
 
     public static boolean getSystemPropertyFlag(final String propertyName) {
-        return Boolean.getBoolean(System.getProperty("coremod."+propertyName, "TRUE"));
+        // this has the property that CoreMods is looking for
+        String property = System.getProperty("coremod."+propertyName, "TRUE");
+
+        // oldLogic = bugged logic that remains included for logical compatibility
+        // newLogic = fixed logic that actually checks if the system property is set to true
+        boolean oldLogic = Boolean.getBoolean(property);
+        boolean newLogic = Boolean.parseBoolean(property);
+
+        // while the two variables can be simplified into a single || statement, this improves readability
+        // and explains the bugged code that caused it in the first place
+        return newLogic || oldLogic;
     }
 
     public enum InsertMode {

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -57,13 +57,13 @@ public class ASMAPI {
     }
 
     public static boolean getSystemPropertyFlag(final String propertyName) {
-        return Boolean.getBoolean("coremod."+propertyName) || getSystemPropertyFlagOld(propertyName);
+        return Boolean.getBoolean("coremod." + propertyName) || getSystemPropertyFlagOld(propertyName);
     }
 
     /** @deprecated Contains the old, bugged logic that {@link #getSystemPropertyFlag(String)} used to have. */
     @Deprecated(forRemoval = true, since = "5.0")
     private static boolean getSystemPropertyFlagOld(final String propertyName) {
-        return Boolean.getBoolean(System.getProperty("coremod."+propertyName, "TRUE"));
+        return Boolean.getBoolean(System.getProperty("coremod." + propertyName, "TRUE"));
     }
 
     public enum InsertMode {


### PR DESCRIPTION
[ASMAPI.getSystemPropertyFlag()](https://github.com/MinecraftForge/CoreMods/blob/303343f84d7ceccb739268b221590b357ecf1bb6/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java#L59-L61) has a very strange logic issue that I believe is the result of an oversight when trying to parse the boolean from the resulting property.

The way it works right now is it gets the property from the system that it wants (say, inputting `"testmod"` will result in CoreMods getting the system property `coremods.testmod`). Then, it uses `Boolean.getBoolean()` to attempt to parse that String. However, this method already has the logic of trying to parse a system property as true in the first place. The correct method to use would be `Boolean.parseBoolean()` or to *not* parse the system property before feeding it into `Boolean.getBoolean()`.

This PR addresses this logic error by correctly utilizing `Boolean.getBoolean()` without parsing the system property early. Additionally, to retain logical compatibility, the old logic is contained in a separate method that is deprecated for removal. This allows developers who heavily utilize coremods to only rely on one system property being implemented, rather than needing a system property string that points to another system property string which equals true.

Here is the documentation for Boolean.getBoolean() (jdk 16 docs because that is the CoreMods current build target): https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/Boolean.html#getBoolean(java.lang.String)