### PR TITLE
Add DYNAMIC enum to ASMAPI.MethodType

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -34,7 +34,7 @@ public class ASMAPI {
     }
 
     public enum MethodType {
-        VIRTUAL, SPECIAL, STATIC, INTERFACE;
+        VIRTUAL, SPECIAL, STATIC, INTERFACE, DYNAMIC;
 
         public int toOpcode() {
             return Opcodes.INVOKEVIRTUAL + this.ordinal();


### PR DESCRIPTION
This is mostly for the sake of convenience and consistency, as many methods within `ASMAPI` require a `MethodType` enum as opposed to an int of the opcode itself.