### PR TITLE
ASMAPI.getSystemPropertyFlag() checks the given property without only prepending "coremod."

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -60,14 +60,28 @@ public class ASMAPI {
                 map(f -> f.apply(domain, name)).orElse(name);
     }
 
+    /**
+     * Checks if the given JVM property is {@code true}.
+     *
+     * @param propertyName the property to check
+     * @return true if the property is true
+     */
     public static boolean getSystemPropertyFlag(final String propertyName) {
-        return Boolean.getBoolean("coremod." + propertyName) || getSystemPropertyFlagOld(propertyName);
+        return Boolean.getBoolean(propertyName) || getSystemPropertyFlagOld("coremod." + propertyName);
     }
 
-    /** @deprecated Contains the old, bugged logic that {@link #getSystemPropertyFlag(String)} used to have. */
+    /**
+     * Contains the old, bugged logic that {@link #getSystemPropertyFlag(String)} used to have. This includes:
+     * <ul>
+     *     <li>Checking if {@code coremod.[propertyName]} is {@code true}.</li>
+     *     <li>Checking if the property that {@code coremod.[propertyName]} points to is {@code true}.</li>
+     * </ul>
+     *
+     * @deprecated Use {@link #getSystemPropertyFlag(String)}
+     */
     @Deprecated(forRemoval = true, since = "5.0")
     private static boolean getSystemPropertyFlagOld(final String propertyName) {
-        return Boolean.getBoolean(System.getProperty("coremod." + propertyName, "TRUE"));
+        return Boolean.getBoolean(propertyName) || Boolean.getBoolean(System.getProperty(propertyName, "TRUE"));
     }
 
     public enum InsertMode {

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -61,13 +61,13 @@ public class ASMAPI {
     }
 
     /**
-     * Checks if the given JVM property is {@code true}.
+     * Checks if the given JVM property (or if the property prepended with {@code "coremod."}) is {@code true}.
      *
      * @param propertyName the property to check
      * @return true if the property is true
      */
     public static boolean getSystemPropertyFlag(final String propertyName) {
-        return Boolean.getBoolean(propertyName) || getSystemPropertyFlagOld("coremod." + propertyName);
+        return Boolean.getBoolean(propertyName) || Boolean.getBoolean("coremod." + propertyName);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -70,20 +70,6 @@ public class ASMAPI {
         return Boolean.getBoolean(propertyName) || Boolean.getBoolean("coremod." + propertyName);
     }
 
-    /**
-     * Contains the old, bugged logic that {@link #getSystemPropertyFlag(String)} used to have. This includes:
-     * <ul>
-     *     <li>Checking if {@code coremod.[propertyName]} is {@code true}.</li>
-     *     <li>Checking if the property that {@code coremod.[propertyName]} points to is {@code true}.</li>
-     * </ul>
-     *
-     * @deprecated Use {@link #getSystemPropertyFlag(String)}
-     */
-    @Deprecated(forRemoval = true, since = "5.0")
-    private static boolean getSystemPropertyFlagOld(final String propertyName) {
-        return Boolean.getBoolean(propertyName) || Boolean.getBoolean(System.getProperty(propertyName, "TRUE"));
-    }
-
     public enum InsertMode {
         REMOVE_ORIGINAL, INSERT_BEFORE, INSERT_AFTER
     }


### PR DESCRIPTION
Successor to #41.

Previously, `ASMAPI.getSystemPropertyFlag()` would prematurely prepend `"coremod."` to the string before checking it using `Boolean.getBoolean()`.  This PR retains that logic, but also checks if the string itself exists as a true property. The old logic contained has been deleted as it has been deprecated for removal since 5.0 and we are now at 5.1 (and who actually uses this except for me lmao).

ASMAPI only checks if the given JVM property boolean is true, so there is no need to worry about "security" (aside from the fact that we're literally talking about Minecraft of all things) when it comes to getting properties.