### PR TITLE
Update ASM to 9.7.1 for Java 24 support

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@ plugins {
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
-            version('asm', '9.7')
+            version('asm', '9.7.1')
             library('asm',         'org.ow2.asm', 'asm'        ).versionRef('asm')
             library('asm-tree',    'org.ow2.asm', 'asm-tree'   ).versionRef('asm')
             library('asm-commons', 'org.ow2.asm', 'asm-commons').versionRef('asm')


### PR DESCRIPTION
Name entails. If you prefer me to include this in a bigger PR, just let me know.