### PR TITLE
Add InsnType for precise instruction searching, additional cleanup

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -543,6 +543,19 @@ public class ASMAPI {
     }
 
     /**
+     * Converts a {@link InsnList} to a string representation, displaying each instruction in the list similar to
+     * {@link #insnToString(InsnNode)}.
+     *
+     * @param list The list to convert.
+     * @return     The string
+     */
+    public static String insnListToString(InsnList list) {
+        Textifier text = new Textifier();
+        list.accept(new TraceMethodVisitor(text));
+        return toString(text);
+    }
+
+    /**
      * Gets the LDC constant's class name as a string. Useful for debugging existing LDC instructions.
      *
      * @param insn The LDC instruction.

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -66,7 +66,7 @@ public class ASMAPI {
      * @return The built method call node
      */
     public static MethodInsnNode buildMethodCall(final String ownerName, final String methodName, final String methodDescriptor, final MethodType type) {
-        return new MethodInsnNode(type.toOpcode(), ownerName, methodName, methodDescriptor, type==MethodType.INTERFACE);
+        return new MethodInsnNode(type.toOpcode(), ownerName, methodName, methodDescriptor, type == MethodType.INTERFACE);
     }
 
     /**
@@ -129,9 +129,9 @@ public class ASMAPI {
     @Deprecated(forRemoval = true, since = "5.1")
     private static String map(String name, INameMappingService.Domain domain) {
         return Optional.ofNullable(Launcher.INSTANCE).
-                map(Launcher::environment).
-                flatMap(env->env.findNameMapping("srg")).
-                map(f -> f.apply(domain, name)).orElse(name);
+                   map(Launcher::environment).
+                   flatMap(env -> env.findNameMapping("srg")).
+                   map(f -> f.apply(domain, name)).orElse(name);
     }
 
     /**
@@ -312,8 +312,7 @@ public class ASMAPI {
      */
     public static InsnList listOf(AbstractInsnNode... nodes) {
         InsnList list = new InsnList();
-        for (AbstractInsnNode node : nodes)
-            list.add(node);
+        for (AbstractInsnNode node : nodes) { list.add(node); }
         return list;
     }
 
@@ -337,19 +336,19 @@ public class ASMAPI {
                 if (foundField == null) {
                     foundField = fieldNode;
                 } else {
-                    throw new IllegalStateException("Found multiple fields with name "+fieldName);
+                    throw new IllegalStateException("Found multiple fields with name " + fieldName);
                 }
             }
         }
 
         if (foundField == null) {
-            throw new IllegalStateException("No field with name "+fieldName+" found");
+            throw new IllegalStateException("No field with name " + fieldName + " found");
         }
         if (!Modifier.isPrivate(foundField.access) || Modifier.isStatic(foundField.access)) {
-            throw new IllegalStateException("Field "+fieldName+" is not private and an instance field");
+            throw new IllegalStateException("Field " + fieldName + " is not private and an instance field");
         }
 
-        final String methodSignature = "()"+foundField.desc;
+        final String methodSignature = "()" + foundField.desc;
 
         for (MethodNode methodNode : classNode.methods) {
             if (Objects.equals(methodNode.desc, methodSignature)) {
@@ -358,13 +357,13 @@ public class ASMAPI {
                 } else if (foundMethod == null && methodName == null) {
                     foundMethod = methodNode;
                 } else if (foundMethod != null && (methodName == null || Objects.equals(methodNode.name, methodName))) {
-                    throw new IllegalStateException("Found duplicate method with signature "+methodSignature);
+                    throw new IllegalStateException("Found duplicate method with signature " + methodSignature);
                 }
             }
         }
 
         if (foundMethod == null) {
-            throw new IllegalStateException("Unable to find method "+methodSignature);
+            throw new IllegalStateException("Unable to find method " + methodSignature);
         }
 
         for (MethodNode methodNode : classNode.methods) {

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -29,7 +29,6 @@ import java.util.function.Function;
  * Helper methods for working with ASM.
  */
 public class ASMAPI {
-    @Deprecated
     public static MethodNode getMethodNode() {
         return new MethodNode(Opcodes.ASM9);
     }

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -159,22 +159,32 @@ public class ASMAPI {
      * @see AbstractInsnNode
      */
     public enum InsnType {
-        INSN,
-        INT_INSN,
-        VAR_INSN,
-        TYPE_INSN,
-        FIELD_INSN,
-        METHOD_INSN,
-        INVOKE_DYNAMIC_INSN,
-        JUMP_INSN,
-        LABEL,
-        LDC_INSN,
-        IINC_INSN,
-        TABLESWITCH_INSN,
-        LOOKUPSWITCH_INSN,
-        MULTIANEWARRAY_INSN,
-        FRAME,
-        LINE
+        INSN(AbstractInsnNode.INSN),
+        INT_INSN(AbstractInsnNode.INT_INSN),
+        VAR_INSN(AbstractInsnNode.VAR_INSN),
+        TYPE_INSN(AbstractInsnNode.TYPE_INSN),
+        FIELD_INSN(AbstractInsnNode.FIELD_INSN),
+        METHOD_INSN(AbstractInsnNode.METHOD_INSN),
+        INVOKE_DYNAMIC_INSN(AbstractInsnNode.INVOKE_DYNAMIC_INSN),
+        JUMP_INSN(AbstractInsnNode.JUMP_INSN),
+        LABEL(AbstractInsnNode.LABEL),
+        LDC_INSN(AbstractInsnNode.LDC_INSN),
+        IINC_INSN(AbstractInsnNode.IINC_INSN),
+        TABLESWITCH_INSN(AbstractInsnNode.TABLESWITCH_INSN),
+        LOOKUPSWITCH_INSN(AbstractInsnNode.LOOKUPSWITCH_INSN),
+        MULTIANEWARRAY_INSN(AbstractInsnNode.MULTIANEWARRAY_INSN),
+        FRAME(AbstractInsnNode.FRAME),
+        LINE(AbstractInsnNode.LINE);
+
+        private final int type;
+
+        InsnType(int type) {
+            this.type = type;
+        }
+
+        public int get() {
+            return type;
+        }
     }
 
     /**
@@ -226,7 +236,7 @@ public class ASMAPI {
         for (int i = Math.max(0, startIndex); i < method.instructions.size(); i++) {
             AbstractInsnNode ain = method.instructions.get(i);
             if (ain.getOpcode() == opCode) {
-                if (!checkType || type.ordinal() == ain.getType()) {
+                if (!checkType || type.get() == ain.getType()) {
                     return ain;
                 }
             }
@@ -259,7 +269,7 @@ public class ASMAPI {
         for (int i = Math.min(method.instructions.size() - 1, startIndex); i >= 0; i--) {
             AbstractInsnNode ain = method.instructions.get(i);
             if (ain.getOpcode() == opCode) {
-                if (!checkType || type.ordinal() == ain.getType()) {
+                if (!checkType || type.get() == ain.getType()) {
                     return ain;
                 }
             }

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -49,10 +49,20 @@ public class ASMAPI {
      * Signifies the method invocation type. Mirrors "INVOKE-" opcodes from ASM.
      */
     public enum MethodType {
-        VIRTUAL, SPECIAL, STATIC, INTERFACE, DYNAMIC;
+        VIRTUAL(Opcodes.INVOKEVIRTUAL),
+        SPECIAL(Opcodes.INVOKESPECIAL),
+        STATIC(Opcodes.INVOKESTATIC),
+        INTERFACE(Opcodes.INVOKEINTERFACE),
+        DYNAMIC(Opcodes.INVOKEDYNAMIC);
+
+        private final int opcode;
+
+        MethodType(int opcode) {
+            this.opcode = opcode;
+        }
 
         public int toOpcode() {
-            return Opcodes.INVOKEVIRTUAL + this.ordinal();
+            return this.opcode;
         }
     }
 

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -381,7 +381,8 @@ public class ASMAPI {
      */
     public static InsnList listOf(AbstractInsnNode... nodes) {
         InsnList list = new InsnList();
-        for (AbstractInsnNode node : nodes) { list.add(node); }
+        for (AbstractInsnNode node : nodes)
+            list.add(node);
         return list;
     }
 

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -153,6 +153,31 @@ public class ASMAPI {
     }
 
     /**
+     * The type of instruction. Useful for searching for a specfic instruction, and is preferred over checking the
+     * opcode or other equivalent.
+     *
+     * @see AbstractInsnNode
+     */
+    public enum InsnType {
+        INSN,
+        INT_INSN,
+        VAR_INSN,
+        TYPE_INSN,
+        FIELD_INSN,
+        METHOD_INSN,
+        INVOKE_DYNAMIC_INSN,
+        JUMP_INSN,
+        LABEL,
+        LDC_INSN,
+        IINC_INSN,
+        TABLESWITCH_INSN,
+        LOOKUPSWITCH_INSN,
+        MULTIANEWARRAY_INSN,
+        FRAME,
+        LINE
+    }
+
+    /**
      * Finds the first instruction with matching opcode.
      *
      * @param method the method to search in
@@ -160,7 +185,19 @@ public class ASMAPI {
      * @return the found instruction node or null if none matched
      */
     public static AbstractInsnNode findFirstInstruction(MethodNode method, int opCode) {
-        return findFirstInstructionAfter(method, opCode, 0);
+        return findFirstInstructionAfter(method, opCode, null, 0);
+    }
+
+    /**
+     * Finds the first instruction with matching opcode.
+     *
+     * @param method the method to search in
+     * @param opCode the opcode to search for
+     * @param type   the instruction type to search for
+     * @return the found instruction node or null if none matched
+     */
+    public static AbstractInsnNode findFirstInstruction(MethodNode method, int opCode, InsnType type) {
+        return findFirstInstructionAfter(method, opCode, type, 0);
     }
 
     /**
@@ -172,10 +209,26 @@ public class ASMAPI {
      * @return the found instruction node or null if none matched after the given index
      */
     public static AbstractInsnNode findFirstInstructionAfter(MethodNode method, int opCode, int startIndex) {
+        return findFirstInstructionAfter(method, opCode, null, startIndex);
+    }
+
+    /**
+     * Finds the first instruction with matching opcode after the given start index
+     *
+     * @param method the method to search in
+     * @param opCode the opcode to search for
+     * @param type   the instruction type to search for
+     * @param startIndex the index to start search after (inclusive)
+     * @return the found instruction node or null if none matched after the given index
+     */
+    public static AbstractInsnNode findFirstInstructionAfter(MethodNode method, int opCode, @Nullable InsnType type, int startIndex) {
+        boolean checkType = type != null;
         for (int i = Math.max(0, startIndex); i < method.instructions.size(); i++) {
             AbstractInsnNode ain = method.instructions.get(i);
             if (ain.getOpcode() == opCode) {
-                return ain;
+                if (!checkType || type.ordinal() == ain.getType()) {
+                    return ain;
+                }
             }
         }
         return null;
@@ -190,10 +243,25 @@ public class ASMAPI {
      * @return the found instruction node or null if none matched before the given startIndex
      */
     public static AbstractInsnNode findFirstInstructionBefore(MethodNode method, int opCode, int startIndex) {
+        return findFirstInstructionBefore(method, opCode, null, startIndex);
+    }
+
+    /**
+     * Finds the first instruction with matching opcode before the given index in reverse search
+     *
+     * @param method the method to search in
+     * @param opCode the opcode to search for
+     * @param startIndex the index at which to start searching (inclusive)
+     * @return the found instruction node or null if none matched before the given startIndex
+     */
+    public static AbstractInsnNode findFirstInstructionBefore(MethodNode method, int opCode, @Nullable InsnType type, int startIndex) {
+        boolean checkType = type != null;
         for (int i = Math.min(method.instructions.size() - 1, startIndex); i >= 0; i--) {
             AbstractInsnNode ain = method.instructions.get(i);
             if (ain.getOpcode() == opCode) {
-                return ain;
+                if (!checkType || type.ordinal() == ain.getType()) {
+                    return ain;
+                }
             }
         }
         return null;

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -29,8 +29,9 @@ import java.util.function.Function;
  * Helper methods for working with ASM.
  */
 public class ASMAPI {
+    @Deprecated
     public static MethodNode getMethodNode() {
-        return new MethodNode(Opcodes.ASM6);
+        return new MethodNode(Opcodes.ASM9);
     }
 
     // Terribly named method. Should be called "prependMethodCall" or something similar.

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -463,6 +463,18 @@ public class ASMAPI {
     }
 
     /**
+     * Converts an {@link InsnNode} to a string representation.
+     *
+     * @param insn The instruction to convert.
+     * @return The string representation of the instruction.
+     */
+    public static String insnToString(InsnNode insn) {
+        Textifier text = new Textifier();
+        insn.accept(new TraceMethodVisitor(text));
+        return toString(text);
+    }
+
+    /**
      * Gets the LDC constant's class name as a string. Useful for debugging existing LDC instructions.
      *
      * @param insn The LDC instruction.


### PR DESCRIPTION
Depends on #48.

This PR's main feature is to addition of enum `InsnType`, which allows for more precise instruction searching within methods. This reduces the need of the end user to continuously make for loops to traverse through method instructions.

Additionally, this PR cleans up formatting, updates `getMethodNode()` to use `Opcodes.ASM9`, and adds a new method `insnToString()` to allow debugging of single instructions.