### PR TITLE
Add LDC constant helper methods

### DIFF
--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Helper methods for working with ASM.
@@ -66,6 +67,37 @@ public class ASMAPI {
      */
     public static MethodInsnNode buildMethodCall(final String ownerName, final String methodName, final String methodDescriptor, final MethodType type) {
         return new MethodInsnNode(type.toOpcode(), ownerName, methodName, methodDescriptor, type==MethodType.INTERFACE);
+    }
+
+    /**
+     * Signifies the type of number constant for a {@link LdcNumberType}.
+     */
+    public enum LdcNumberType {
+        INTEGER(Number::intValue),
+        FLOAT(Number::floatValue),
+        LONG(Number::longValue),
+        DOUBLE(Number::doubleValue);
+
+        private final Function<Number, Object> mapper;
+
+        LdcNumberType(Function<Number, Object> mapper) {
+            this.mapper = mapper;
+        }
+
+        public Object map(Number number) {
+            return mapper.apply(number);
+        }
+    }
+
+    /**
+     * Builds a new {@link LdcInsnNode} with the given number value and type.
+     *
+     * @param value The number value
+     * @param type  The type of the number
+     * @return The built LDC node
+     */
+    public static LdcInsnNode buildNumberLdcInsnNode(final Number value, final LdcNumberType type) {
+        return new LdcInsnNode(type.map(value));
     }
 
     /**

--- a/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -462,6 +462,16 @@ public class ASMAPI {
         return toString(text);
     }
 
+    /**
+     * Gets the LDC constant's class name as a string. Useful for debugging existing LDC instructions.
+     *
+     * @param insn The LDC instruction.
+     * @return The class name of the LDC constant.
+     */
+    public static String ldcInsnClassToString(LdcInsnNode insn) {
+        return insn.cst.getClass().toString();
+    }
+
     private static String toString(Textifier text) {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);


### PR DESCRIPTION
This PR aims to address the pains of dealing with LDC constant instructions.

- The `buildLdcInsnNode()` method uses a `LdcNumberType` to ensure that the exact type of number is fed into the `LdcInsnNode` constructor. Fixes #42.
- The `ldcInsnClassToString` method gets the class name of the constant stored in the given `LdcInsnNode`, making it easier to debug existing LDC constant instructions. Fixes #30.

Will remain as draft until I test these additions myself.