### PR TITLE
Update build setup, Gradle 8.10.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 group 'net.minecraftforge'
 version = gradleutils.tagOffsetVersion
-println("Version: $version")
+println "Version: $version"
 
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(17)
@@ -93,22 +93,19 @@ publishing {
 
 allprojects {
     ext.VALID_VMS = [
-        'Adoptium':  [16, 17, 18, 19, 20, 21],
-        'Amazon':    [16, 17, 18, 19, 20, 21],
-        'Azul':      (16..21),
-        'BellSoft':  (16..21),
-        'Graal_VM':  [16, 17,     19, 20, 21],
-        'IBM':       [16, 17, 18, 19, 20    ],
-        'Microsoft': [16, 17,             21],
-        'Oracle':    (16..21),
-        'SAP':       (16..20)
+        'Adoptium':  [17, 18, 19, 20, 21],
+        'Amazon':    [17, 18, 19, 20, 21],
+        'Azul':      (17..21),
+        'BellSoft':  (17..21),
+        'Graal_VM':  [17,     19, 20, 21],
+        'IBM':       [17, 18, 19, 20    ],
+        'Microsoft': [17,             21],
+        'Oracle':    (17..21),
+        'SAP':       (17..20)
     ]
-    ext.VALID_VMS = [ 'Adoptium':  [16] ]
+    ext.VALID_VMS = [ 'Adoptium':  [17] ]
 }
 
-idea {
-    module {
-        downloadJavadoc = true
-        downloadSources = true
-    }
+idea.module {
+    downloadJavadoc = downloadSources = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compileOnly(libs.nulls)
 }
 
-jar {
+tasks.named('jar', Jar) {
     manifest {
         attributes([
             'Specification-Title': 'coremods',
@@ -64,7 +64,7 @@ jar {
             'Implementation-Title': project.name,
             'Implementation-Version': project.version,
             'Implementation-Vendor' :'Forge Development LLC'
-        ] as java.util.LinkedHashMap, 'net/minecraftforge/coremod/')
+        ], 'net/minecraftforge/coremod/')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,8 +93,8 @@ publishing {
 
 allprojects {
     ext.VALID_VMS = [
-        'Adoptium':  [17, 18, 19, 20, 21],
-        'Amazon':    [17, 18, 19, 20, 21],
+        'Adoptium':  (17..21),
+        'Amazon':    (17..21),
         'Azul':      (17..21),
         'BellSoft':  (17..21),
         'Graal_VM':  [17,     19, 20, 21],

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 import net.minecraftforge.gradleutils.PomUtils
 
 plugins {
-    id 'org.cadixdev.licenser' version '0.6.1'
+    id 'net.minecraftforge.licenser' version '1.0.1'
     id 'idea'
     id 'eclipse'
     id 'java-library'
     id 'maven-publish'
-    id 'net.minecraftforge.gradleutils' version '[2.1.2,2.3.0)'
+    id 'net.minecraftforge.gradleutils' version '[2.1.3,2.3.0)'
 }
 
 group 'net.minecraftforge'

--- a/coremods-test-jar/build.gradle
+++ b/coremods-test-jar/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 java {
-    toolchain.languageVersion = JavaLanguageVersion.of(16)
+    toolchain.languageVersion = JavaLanguageVersion.of(17)
 }
 
 license {

--- a/coremods-test-jar/build.gradle
+++ b/coremods-test-jar/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id 'org.cadixdev.licenser' version '0.6.1'
+    id 'net.minecraftforge.licenser' version '1.0.1'
     id 'eclipse'
     id 'java-library'
-    id 'net.minecraftforge.gradleutils' version '[2.1.2,2.3.0)'
+    id 'net.minecraftforge.gradleutils' version '[2.1.3,2.3.0)'
 }
 
 repositories {

--- a/coremods-test/build.gradle
+++ b/coremods-test/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'eclipse'
     id 'java-library'
-    id 'org.gradlex.extra-java-module-info' version '1.4.2'
+    id 'org.gradlex.extra-java-module-info' version '1.9'
     id 'net.minecraftforge.gradleutils' version '[2.1.2,2.3.0)'
 }
 

--- a/coremods-test/build.gradle
+++ b/coremods-test/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id 'org.cadixdev.licenser' version '0.6.1'
+    id 'net.minecraftforge.licenser' version '1.0.1'
     id 'eclipse'
     id 'java-library'
     id 'org.gradlex.extra-java-module-info' version '1.9'
-    id 'net.minecraftforge.gradleutils' version '[2.1.2,2.3.0)'
+    id 'net.minecraftforge.gradleutils' version '[2.1.3,2.3.0)'
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This PR does two main things:
- Updates Gradle and build deps
- Uses Java 17 everywhere
    - The main project compiles with Java 17 already, so defaulting to Java 16 for tests and such doesn't make sense