### PR TITLE
Fix modules error on compile-time

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -11,9 +11,10 @@ module net.minecraftforge.coremod {
     requires cpw.mods.modlauncher;
     requires net.minecraftforge.forgespi;
     requires org.apache.logging.log4j;
-    requires org.jetbrains.annotations;
     requires org.openjdk.nashorn;
     requires org.objectweb.asm.util;
+
+    requires static org.jetbrains.annotations;
 
     provides net.minecraftforge.forgespi.coremod.ICoreModProvider
         with net.minecraftforge.coremod.CoreModProvider;


### PR DESCRIPTION
Changes the `org.jetbrains.annotations` requirement to be static. Please merge this as soon as possible.

- Fixes #65.