### PR TITLE
Split ASMAPI into a seperate artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
     uses: MinecraftForge/SharedActions/.github/workflows/gradle.yml@main
     with:
       java: 17
-      gradle_tasks: "publish"
-      artifact_name: "coremods"
+      gradle_tasks: "publish coremods-api:publish"
+      artifact_names: "coremods,coremods-api"
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       PROMOTE_ARTIFACT_WEBHOOK: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK }}

--- a/coremods-api/build.gradle
+++ b/coremods-api/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = 'net.minecraftforge'
-version = gradleutils.tagOffsetVersion
+version = rootProject.version
 println "Version: $version"
 
 java {
@@ -25,48 +25,41 @@ repositories {
     mavenLocal()
 }
 
-changelog {
-    from '1.0.0'
-    publishAll = false
-}
-
 license {
-    header = file('LICENSE-header.txt')
+    header = rootProject.file('LICENSE-header.txt')
     newLine = false
 }
 
 dependencies {
     compileOnly(libs.modlauncher)
-    compileOnly(libs.securemodules)
-    compileOnly(libs.log4j.api)
+    compileOnly(libs.securemodules) // Needed by Modlauncher
+
     compileOnly(libs.nulls)
-    compileOnly(libs.forgespi)
+    compileOnly(rootProject)
 
     api(libs.bundles.asm)
-    implementation(libs.nashorn)
 }
 
 tasks.named('jar', Jar) {
     manifest {
         attributes([
-            'Specification-Title': 'coremods',
+            'Specification-Title': 'coremods-api',
             'Specification-Vendor': 'Forge Development LLC',
             'Specification-Version': '1', // TODO: Use the tag
             'Implementation-Title': project.name,
             'Implementation-Version': project.version,
             'Implementation-Vendor' :'Forge Development LLC'
-        ], 'net/minecraftforge/coremod/')
+        ], 'net/minecraftforge/coremod/api/')
     }
 }
 
 publishing {
     publications.register('mavenJava', MavenPublication) {
-    	changelog.publish(it)
         pom {
             from components.java
-            artifactId = 'coremods'
-            name = 'Core Mods'
-            description = 'JavaScript based core modding framework for use with Forge'
+            artifactId = 'coremods-api'
+            name = 'Core Mods API'
+            description = 'API that is useful for Minecraft Transformers'
             url = 'https://github.com/MinecraftForge/CoreMods'
             PomUtils.setGitHubDetails(pom, 'CoreMods')
             license PomUtils.Licenses.LGPLv2_1
@@ -81,21 +74,6 @@ publishing {
     repositories {
         maven gradleutils.publishingForgeMaven
     }
-}
-
-allprojects {
-    ext.VALID_VMS = [
-        'Adoptium':  (17..21),
-        'Amazon':    (17..21),
-        'Azul':      (17..21),
-        'BellSoft':  (17..21),
-        'Graal_VM':  [17,     19, 20, 21],
-        'IBM':       [17, 18, 19, 20    ],
-        'Microsoft': [17,             21],
-        'Oracle':    (17..21),
-        'SAP':       (17..20)
-    ]
-    ext.VALID_VMS = [ 'Adoptium':  [17] ]
 }
 
 idea.module {

--- a/coremods-api/src/main/java/module-info.java
+++ b/coremods-api/src/main/java/module-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+module net.minecraftforge.coremod.api {
+    // ASMAPI
+    exports net.minecraftforge.coremod.api;
+
+    requires cpw.mods.modlauncher;
+
+    requires static org.jetbrains.annotations;
+	requires org.objectweb.asm.util;
+
+	// JavaScript specific helpers.
+	requires static net.minecraftforge.coremod;
+}

--- a/coremods-api/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/coremods-api/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -1121,7 +1121,6 @@ public class ASMAPI {
      *     still work for sake of backwards-compatibility, you should not be using this method if you are on 1.20.4 or
      *     later.
      */
-    @Deprecated(forRemoval = true, since = "5.2")
     public static String mapMethod(String name) {
         return map(name, INameMappingService.Domain.METHOD);
     }
@@ -1136,7 +1135,6 @@ public class ASMAPI {
      *     still work for sake of backwards-compatibility, you should not be using this method if you are on 1.20.4 or
      *     later.
      */
-    @Deprecated(forRemoval = true, since = "5.2")
     public static String mapField(String name) {
         return map(name, INameMappingService.Domain.FIELD);
     }

--- a/coremods-api/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
+++ b/coremods-api/src/main/java/net/minecraftforge/coremod/api/ASMAPI.java
@@ -6,8 +6,9 @@ package net.minecraftforge.coremod.api;
 
 import cpw.mods.modlauncher.Launcher;
 import cpw.mods.modlauncher.api.INameMappingService;
-import net.minecraftforge.coremod.CoreModEngine;
+import cpw.mods.modlauncher.api.TypesafeMap;
 import net.minecraftforge.coremod.CoreModTracker;
+
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
@@ -15,7 +16,6 @@ import org.objectweb.asm.util.Textifier;
 import org.objectweb.asm.util.TraceClassVisitor;
 import org.objectweb.asm.util.TraceMethodVisitor;
 
-import javax.script.ScriptException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -31,7 +31,7 @@ import java.util.function.Function;
  * to prevent boilerplate code, excessive imports, unnecessary loops, and to provide a more user-friendly API for
  * coremod developers.
  */
-@SuppressWarnings({"unused", "exports"}) // annoying IDE warnings
+@SuppressWarnings({"exports"}) // annoying IDE warnings
 public class ASMAPI {
     /* BUILDING INSTRUCTION LISTS */
 
@@ -473,7 +473,7 @@ public class ASMAPI {
      *     {@link #findFirstInstructionBefore(MethodNode, int, InsnType, int, boolean)}.
      */
     public static @Nullable AbstractInsnNode findFirstInstructionBefore(MethodNode method, int opCode, @Nullable InsnType type, int startIndex) {
-        return findFirstInstructionBefore(method, opCode, type, startIndex, !CoreModEngine.DO_NOT_FIX_INSNBEFORE);
+        return findFirstInstructionBefore(method, opCode, type, startIndex, !DO_NOT_FIX_INSNBEFORE);
     }
 
     /**
@@ -1121,6 +1121,7 @@ public class ASMAPI {
      *     still work for sake of backwards-compatibility, you should not be using this method if you are on 1.20.4 or
      *     later.
      */
+    @Deprecated(forRemoval = true, since = "5.2")
     public static String mapMethod(String name) {
         return map(name, INameMappingService.Domain.METHOD);
     }
@@ -1135,6 +1136,7 @@ public class ASMAPI {
      *     still work for sake of backwards-compatibility, you should not be using this method if you are on 1.20.4 or
      *     later.
      */
+    @Deprecated(forRemoval = true, since = "5.2")
     public static String mapField(String name) {
         return map(name, INameMappingService.Domain.FIELD);
     }
@@ -1171,8 +1173,11 @@ public class ASMAPI {
      *
      * @throws ScriptException If the script engine encounters an error, usually due to a syntax error in the script
      * @throws IOException     If an I/O error occurs while reading the file, usually due to a corrupt or missing file
+     *
+     * @apiNote This method only functions for JavaScript coremods managed by the main CoreMod engine.
+     * If using ASMAPI in a normal transformer do not use this method. Unknown exceptions could be thrown.
      */
-    public static boolean loadFile(String file) throws ScriptException, IOException {
+    public static boolean loadFile(String file) throws IOException {
         return CoreModTracker.loadFileByName(file);
     }
 
@@ -1184,10 +1189,13 @@ public class ASMAPI {
      *     {@code initializeCoreMod()} or any of the transformer functions returned by it.
      *
      * @throws ScriptException If the parsed JSON data is malformed
-     * @throws IOException     If an I/O error occurs while reading the file, usually due to a corrupt or missing file
+     * @throws IOException     If an I/O error occurs while reading the file, usually due to a corrupt or missing file.
+     *
+     * @apiNote This method only functions for JavaScript coremods managed by the main CoreMod engine.
+     * If using ASMAPI in a normal transformer do not use this method. Unknown exceptions could be thrown.
      */
     @Nullable
-    public static Object loadData(String file) throws ScriptException, IOException {
+    public static Object loadData(String file) throws IOException {
         return CoreModTracker.loadDataByName(file);
     }
 
@@ -1202,6 +1210,9 @@ public class ASMAPI {
      * @param message The message
      * @param args    Any formatting arguments
      * @see CoreModTracker#log(String, String, Object[])
+     *
+     * @apiNote This method only functions for JavaScript coremods managed by the main CoreMod engine.
+     * If using ASMAPI in a normal transformer do not use this method. Unknown exceptions could be thrown.
      */
     public static void log(String level, String message, Object... args) {
         CoreModTracker.log(level, message, args);
@@ -1292,5 +1303,30 @@ public class ASMAPI {
     // private because this is really only used to clamp indexes
     private static int clamp(int value, int min, int max) {
         return Math.max(min, Math.min(max, value));
+    }
+
+    // INTERNAL
+    /**
+     * Whether to preserve the legacy behavior of
+     * {@link net.minecraftforge.coremod.api.ASMAPI#findFirstInstructionBefore(org.objectweb.asm.tree.MethodNode, int,
+     * int)} for backwards-compatibility.
+     * <p>
+     * In Forge's case, this is set by FML in Minecraft 1.21.1 and earlier, but not in 1.21.3 and later.
+     *
+     * @see net.minecraftforge.coremod.api.ASMAPI#findFirstInstructionBefore(org.objectweb.asm.tree.MethodNode, int,
+     *     int)
+     */
+    private static final boolean DO_NOT_FIX_INSNBEFORE = shouldntFixInsnBefore();
+
+    private static final boolean shouldntFixInsnBefore() {
+    	try {
+	        if (Launcher.INSTANCE == null)
+	            return false;
+
+	        var blackboardVar = Launcher.INSTANCE.blackboard().get(TypesafeMap.Key.getOrCreate(Launcher.INSTANCE.blackboard(), "coremods.use_old_findFirstInstructionBefore", Boolean.class));
+	        return blackboardVar.isPresent() && blackboardVar.get();
+    	} catch (Throwable t) { // If ModLauncher doesn't exist.
+    		return false;
+    	}
     }
 }

--- a/coremods-test/build.gradle
+++ b/coremods-test/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'eclipse'
     id 'java-library'
     alias libs.plugins.license
-    alias libs.plugins.modules
     //alias libs.plugins.versions
     alias libs.plugins.gradleutils
 }
@@ -56,11 +55,6 @@ dependencies {
     testImplementation(libs.unsafe)
     testRuntimeOnly(libs.bundles.junit.runtime)
     testCompileOnly(libs.nulls)
-}
-
-extraJavaModuleInfo {
-    failOnMissingModuleInfo = false
-    automaticModule('jopt-simple-5.0.4.jar', 'jopt.simple')
 }
 
 // If we are being told a specific vendor then we are probably being run in parallel

--- a/coremods-test/src/test/resources/log4j2.xml
+++ b/coremods-test/src/test/resources/log4j2.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) Forge Development LLC
-    SPDX-License-Identifier: LGPL-3.0-only
+    SPDX-License-Identifier: LGPL-2.1-only
 -->
-
 <Configuration status="OFF" packages="cpw.mods.modlauncher">
     <filters>
         <MarkerFilter marker="MODLAUNCHER" onMatch="DENY" onMismatch="DENY" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 org.gradle.configureondemand=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
 org.gradle.configureondemand=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,13 +16,14 @@ dependencyResolutionManagement {
             plugin('gradleutils', 'net.minecraftforge.gradleutils').version('[2.3,2.4)')
             plugin('modules', 'org.gradlex.extra-java-module-info').version('1.9')
             plugin('versions', 'com.github.ben-manes.versions').version('0.51.0')
-        
+
             version('asm', '9.7.1')
             library('asm',         'org.ow2.asm', 'asm'        ).versionRef('asm')
             library('asm-tree',    'org.ow2.asm', 'asm-tree'   ).versionRef('asm')
             library('asm-commons', 'org.ow2.asm', 'asm-commons').versionRef('asm')
-            bundle('asm', ['asm', 'asm-tree', 'asm-commons'])
-            
+            library('asm-util',    'org.ow2.asm', 'asm-util'   ).versionRef('asm')
+            bundle('asm', ['asm', 'asm-tree', 'asm-commons', 'asm-util'])
+
             version('junit', '5.11.4')
             library('junit-api', 'org.junit.jupiter', 'junit-jupiter-api').versionRef('junit')
             library('junit-engine', 'org.junit.jupiter', 'junit-jupiter-engine').versionRef('junit')
@@ -35,16 +36,16 @@ dependencyResolutionManagement {
             library('gson', 'com.google.code.gson:gson:2.10.1')
             library('jopt-simple', 'net.sf.jopt-simple:jopt-simple:5.0.4')
             */
-            
-            library('forgespi', 'net.minecraftforge:forgespi:7.1.0') 
+
+            library('forgespi', 'net.minecraftforge:forgespi:7.1.0')
             library('modlauncher', 'net.minecraftforge:modlauncher:10.1.1') // Needs securemodules
             library('nulls', 'org.jetbrains:annotations:26.0.1')
             library('nashorn', 'org.openjdk.nashorn:nashorn-core:15.4') // Needed by coremods, because the JRE no longer ships JS
-            
+
             // Used by our test aggrigator scripts
             library('ivy', 'org.apache.ivy:ivy:2.5.3')
             library('groovy', 'org.codehaus.groovy:groovy-all:3.0.23')
-            
+
             version('log4j', '2.17.0') // Needs to be kept in step with modlauncher because of its config.. TODO: Figure out why?
             library('log4j-api',  'org.apache.logging.log4j', 'log4j-api' ).versionRef('log4j')
             library('log4j-core', 'org.apache.logging.log4j', 'log4j-core').versionRef('log4j')
@@ -52,6 +53,7 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = 'CoreMods'
+rootProject.name = 'coremods'
+include 'coremods-api'
 include 'coremods-test'
 include 'coremods-test-jar'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,8 +5,6 @@
 module net.minecraftforge.coremod {
     // CoreMods framework
     exports net.minecraftforge.coremod;
-    // ASMAPI
-    exports net.minecraftforge.coremod.api;
 
     requires cpw.mods.modlauncher;
     requires net.minecraftforge.forgespi;

--- a/src/main/java/net/minecraftforge/coremod/CoreMod.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreMod.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -116,8 +117,6 @@ public class CoreMod {
                 throw new RuntimeException("Unimplemented target type " + targetData);
         }
     }
-
-
 
     private static String map(String name, INameMappingService.Domain domain) {
         final class LazyInit {

--- a/src/main/java/net/minecraftforge/coremod/CoreMod.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreMod.java
@@ -120,10 +120,17 @@ public class CoreMod {
 
 
     private static String map(String name, INameMappingService.Domain domain) {
-    	if (Launcher.INSTANCE == null || Launcher.INSTANCE.environment() == null)
-    		return name;
-    	var mapper = Launcher.INSTANCE.environment().findNameMapping("srg").orElse(null);
-    	return mapper == null ? name : mapper.apply(domain, name);
+        final class LazyInit {
+            static final BiFunction<INameMappingService.Domain, String, String> MAPPER;
+            static {
+                BiFunction<INameMappingService.Domain, String, String> mapper = null;
+                if (Launcher.INSTANCE != null && Launcher.INSTANCE.environment() != null) {
+                    mapper = Launcher.INSTANCE.environment().findNameMapping("srg").orElse(null);
+                }
+                MAPPER = mapper;
+            }
+        }
+        return LazyInit.MAPPER == null ? name : LazyInit.MAPPER.apply(domain, name);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/coremod/CoreModTracker.java
+++ b/src/main/java/net/minecraftforge/coremod/CoreModTracker.java
@@ -43,7 +43,7 @@ public class CoreModTracker {
      * @throws IOException     If an I/O error occurs while reading the file, usually due to a corrupt or missing file
      * @see net.minecraftforge.coremod.api.ASMAPI#loadFile(String)
      */
-    public static boolean loadFileByName(final String file) throws ScriptException, IOException {
+    public static boolean loadFileByName(final String file) throws IOException {
         final CoreMod tracked = LOCAL.get().tracked;
         if (tracked != null) {
             return tracked.loadAdditionalFile(file);
@@ -62,7 +62,7 @@ public class CoreModTracker {
      * @see net.minecraftforge.coremod.api.ASMAPI#loadData(String)
      */
     @Nullable
-    public static Object loadDataByName(final String file) throws ScriptException, IOException {
+    public static Object loadDataByName(final String file) throws IOException {
         final CoreMod tracked = LOCAL.get().tracked;
         if (tracked != null) {
             return tracked.loadAdditionalData(file);


### PR DESCRIPTION
Quick pass to split ASMAPI into its own jar for use in Forge when not using JavaScript coremods.
There are 3 methods that call into the JavaScript coremoding manager, `loadFile`, `loadData`, and `log`.
These methods are expected to throw exceptions if invoked from a non-JS transformer. So it should be fine.

For old versions that ship the JS engine, they will now need to ship the ASMAPI artifact as well.